### PR TITLE
Setup manual

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,36 @@
+# MariaDB using Docker
+
+- 설정
+
+1. Docker container 생성
+
+  - `my-secret-pw` 는 `root` 계정 비밀번호이므로 적절히 설정
+  - `bboombboom` 은 Container 이름이므로 적절히 변경
+
+```bash
+docker pull mariadb
+docker run --restart unless-stopped --name bboomboom -p 3306:3306 -e MARIADB_ROOT_PASSWORD=my-secret-pw -d mariadb:latest
+```
+2. Docker 접속
+
+```bash
+docker exec -it bboombboom bash
+mariadb -uroot -p
+```
+
+3. Database and table 생성
+
+  - `b4db`는 데이터베이스 이름
+  - `b4user`는 사용자 계정 이름
+  - `user-secret-pw`는 사용자 계정 비밀번호
+
+```
+CREATE DATABASE b4db;
+CREATE USER IF NOT EXISTS b4user@b4db IDENTIFIED BY 'user-secret-pw';
+SHOW WARNINGS;
+GRANT ALL PRIVILEGES ON b4db.* TO 'b4user'@'%' IDENTIFIED BY 'user-secret-pw';
+FLUSH PRIVILEGES;
+```
+
+4. DB Connector 활용 데이터베이스 접근 및 활용
+


### PR DESCRIPTION
데이터베이스 스크립트 작성 중 Root 계정 및 사용자 계정 등에 대한 정보를 고정시켜두는 것이 부적절해보임.
따라서, 매뉴얼을 기준으로 수동으로 셋업
이후, 사용자에게 입력을 받아서 수행하는 스크립트로 만들어두면 편할 듯.

For https://github.com/mirasoy/bboombboom/issues/4